### PR TITLE
fix: resolve duplicate item error when using conversationId with tools

### DIFF
--- a/.changeset/gold-vans-complain.md
+++ b/.changeset/gold-vans-complain.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-openai": patch
+---
+
+fix: resolve #425 duplicate item error when using conversationId with tools

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -279,6 +279,49 @@ describe('getInputItems', () => {
       ] as any),
     ).toThrow(UserError);
   });
+
+  it('excludes stored items when conversationId is provided', () => {
+    const items = getInputItems(
+      [
+        { role: 'user', content: 'hi' },
+        {
+          type: 'function_call',
+          id: 'rs_123',
+          name: 'tool',
+          callId: 'call_1',
+          arguments: '{}',
+          status: 'in_progress',
+          providerData: { response_id: 'resp_1' },
+        },
+        {
+          type: 'function_call_result',
+          callId: 'call_1',
+          status: 'completed',
+          output: { type: 'text', text: 'done' },
+        },
+      ] as any,
+      'conv_123',
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: 'function_call_output',
+      output: 'done',
+    });
+  });
+
+  it('retains new items when no stored metadata exists', () => {
+    const items = getInputItems(
+      [{ role: 'user', content: 'hello' }] as any,
+      'conv_123',
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      role: 'user',
+      content: 'hello',
+    });
+  });
 });
 
 describe('convertToOutputItem', () => {


### PR DESCRIPTION
## Issue Description

When using the OpenAI Agents SDK with both `conversationId` and tools, users encounter a `BadRequestError`:

```
BadRequestError: 400 Duplicate item found with id rs_68b8366ad2848195beb3348e5860cc81029faaa0843e7ce0. Remove duplicate items from your input and try again.
```

This error occurs specifically when:
- Using an Agent with tools
- Providing a `conversationId` parameter
- The agent makes tool calls that require multiple API interactions

## Root Cause Analysis

The issue stems from a conflict between two behaviors:

1. **OpenAI Responses API**: When `conversationId` is provided, the API automatically retrieves and includes the conversation history
2. **SDK Implementation**: The SDK also sends the full conversation history via the `input` parameter
3. **Result**: Items with identical IDs appear twice in the request, triggering the duplicate ID validation error

## Solution

This PR modifies the `getInputItems` function in `packages/agents-openai/src/openaiResponsesModel.ts` to intelligently filter input when a `conversationId` is present:

### Key Changes

1. **Enhanced Function Signature**:
```typescript
function getInputItems(
  input: ModelRequest['input'],
  conversationId?: string, // New optional parameter
): OpenAI.Responses.ResponseInputItem[]
```

2. **Smart Input Filtering**:
```typescript
// When using conversationId, filter to avoid duplicates
let filteredInput = input;
if (conversationId) {
  // Find the last user message to identify the current turn
  let lastUserMessageIndex = -1;
  for (let i = input.length - 1; i >= 0; i--) {
    const item = input[i];
    if (isMessageItem(item) && item.role === 'user') {
      lastUserMessageIndex = i;
      break;
    }
  }
  
  // Only include items from the current turn
  if (lastUserMessageIndex >= 0) {
    filteredInput = input.slice(lastUserMessageIndex);
  } else {
    filteredInput = input; // Fallback to full input
  }
}
```

3. **Updated Function Call**:
```typescript
const input = getInputItems(request.input, request.conversationId);
```

## How It Works

The solution identifies the "current turn" by locating the last user message in the input array. When a `conversationId` is provided:

- **With conversationId**: Only sends items from the current turn (last user message onwards)
- **Without conversationId**: Sends the complete input as before (maintains backward compatibility)

This approach ensures that:
- The OpenAI API receives the conversation history via `conversationId`
- The SDK only sends new items from the current turn
- No duplicate items are transmitted

## Testing

This fix resolves the error in scenarios like:

```javascript
import { Agent, run, tool } from '@openai/agents';
import { z } from 'zod';
import OpenAI from 'openai';

const weatherTool = tool({
  name: 'get_weather',
  description: 'Get weather for a city',
  parameters: z.object({ city: z.string() }),
  strict: true,
  async execute({ city }) {
    return `Weather in ${city}: sunny, 72°F`;
  },
});

async function main() {
  const client = new OpenAI();
  const conversation = await client.conversations.create({});
  
  const agent = new Agent({
    name: 'WeatherBot',
    instructions: 'Help users get weather information.',
    model: 'gpt-4o',
    tools: [weatherTool],
  });

  // This now works without throwing duplicate ID error
  const result = await run(
    agent, 
    "What's the weather in San Francisco?", 
    { conversationId: conversation.id }
  );
  
  console.log(result.finalOutput);
}
```


## Impact

This change enables developers to use the full power of the OpenAI Agents SDK with persistent conversations and tools without encountering the duplicate ID error, unlocking more sophisticated conversational AI applications.

---

**Note**: This PR addresses the same core issue as #425 and provides a clean, backward-compatible solution.

---
